### PR TITLE
gamepad support where keys are enabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ bevy = { version = "0.14.0", default-features = false, features = [
     "bevy_winit",
     "bevy_core_pipeline",
     "bevy_render",
+    "bevy_gilrs",
     "bevy_text",
     "bevy_ui",
     "multi_threaded",
@@ -19,7 +20,7 @@ bevy = { version = "0.14.0", default-features = false, features = [
     "shader_format_glsl",
     "wav",
     "bevy_state",
-    "webgl2"
+    "webgl2",
 ] }
 bevy_ecs_ldtk = { version = "0.10.0", features = ["atlas"] }
 bevy_ecs_tilemap = "0.14.0"
@@ -36,6 +37,3 @@ opt-level = 3
 
 [profile.release]
 opt-level = "z"
-
-
-

--- a/src/entities/door.rs
+++ b/src/entities/door.rs
@@ -120,16 +120,24 @@ pub fn check_door_interacting(
     query_player_collider: Query<Entity, With<PlayerColliderMarker>>,
     mut query_door_state: Query<(Entity, &mut DoorAnimationState, &mut DoorState)>,
     keys: Res<ButtonInput<KeyCode>>,
+    gamepads: Res<Gamepads>,
+    button_inputs: Res<ButtonInput<GamepadButton>>,
     mut checkpoint_event_writer: EventWriter<SetCheckpointEvent>,
     mut sound_effect_event_writer: EventWriter<SoundEffectEvent>,
 ) {
+    let gamepad = match gamepads.iter().next() {
+        Some(gp) => gp,
+        None => Gamepad::new(0),
+    };
     let Ok(mut inventory) = query_player.get_single_mut() else {
         return;
     };
     let Ok(player_collider) = query_player_collider.get_single() else {
         return;
     };
-    if !keys.just_pressed(INTERACT_KEYCODE) {
+    if !keys.just_pressed(INTERACT_KEYCODE)
+        && !button_inputs.just_pressed(GamepadButton::new(gamepad, GamepadButtonType::West))
+    {
         return;
     }
 

--- a/src/entities/lever.rs
+++ b/src/entities/lever.rs
@@ -138,13 +138,21 @@ pub fn check_lever_interacting(
         With<PlatformMarker>,
     >,
     keys: Res<ButtonInput<KeyCode>>,
+    gamepads: Res<Gamepads>,
+    button_inputs: Res<ButtonInput<GamepadButton>>,
     mut checkpoint_event_writer: EventWriter<SetCheckpointEvent>,
     mut sound_effect_event_writer: EventWriter<SoundEffectEvent>,
 ) {
+    let gamepad = match gamepads.iter().next() {
+        Some(gp) => gp,
+        None => Gamepad::new(0),
+    };
     let Ok(player_collider) = query_player_collider.get_single() else {
         return;
     };
-    if !keys.just_pressed(INTERACT_KEYCODE) {
+    if !keys.just_pressed(INTERACT_KEYCODE)
+        && !button_inputs.just_pressed(GamepadButton::new(gamepad, GamepadButtonType::West))
+    {
         return;
     }
 

--- a/src/sound_effects.rs
+++ b/src/sound_effects.rs
@@ -94,8 +94,16 @@ fn update_muted(
     mut muted: ResMut<AudioMuted>,
     keys: Res<ButtonInput<KeyCode>>,
     query_bgm: Query<&AudioSink, With<BackgroundMusicMarker>>,
+    gamepads: Res<Gamepads>,
+    button_inputs: Res<ButtonInput<GamepadButton>>,
 ) {
-    if keys.just_pressed(KeyCode::KeyM) {
+    let gamepad = match gamepads.iter().next() {
+        Some(gp) => gp,
+        None => Gamepad::new(0),
+    };
+    if keys.just_pressed(KeyCode::KeyM)
+        || button_inputs.just_pressed(GamepadButton::new(gamepad, GamepadButtonType::Select))
+    {
         muted.0 = !muted.0;
         let Ok(bgm) = query_bgm.get_single() else {
             return;


### PR DESCRIPTION
I wasn't sure if letting the interact key of "x" need a gamepad mapping for the user, but I figured I'd map interact to where most gamepads put the "x" which is the "west" button.  Fixes #37 